### PR TITLE
Update build_apps.py

### DIFF
--- a/installer/ui/build_apps.py
+++ b/installer/ui/build_apps.py
@@ -7,7 +7,7 @@ from os import walk
 import boto3
 
 class BuildPacman(object):
-    git_repo_url = "git@github.com:tmobile/pacbot.git"  # This should be changed based on the Repo
+    git_repo_url = "https://github.com/tmobile/pacbot.git"  # This should be changed based on the Repo
     pacman_clone_path = "pacman_cloned_dir_"  # This should be changed based on the system
 
     mvn_build_command = "mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V"


### PR DESCRIPTION
## Why

Installer failed when running as sudo since the root user does not have ssh keys setup.  Since this is a public repo there is no need to use ssh to clone the repo.