### PR TITLE
Policy evaluation as empty list on no issues

### DIFF
--- a/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/service/PolicyAssetServiceImpl.java
+++ b/api/pacman-api-compliance/src/main/java/com/tmobile/pacman/api/compliance/service/PolicyAssetServiceImpl.java
@@ -59,7 +59,7 @@ public class PolicyAssetServiceImpl implements PolicyAssetService, Constants {
 			throw new ServiceException("Error fetching issues from ES",e);
 		}
         List<PolicyScanInfo> scanList = new ArrayList<>();
-        if (issueList != null && !issueList.isEmpty()) {
+        if (issueList != null) {
 
             for (Map<String, Object> rule : rules) {
                 PolicyScanInfo scanInfo = new PolicyScanInfo();


### PR DESCRIPTION
When there are no issues for a resource, API is returning empty list not the policy evaluation with pass