### PR TITLE
Asset Group Adding backward slash to API endpoint and Java8 Base64 encoding instead of Sun classes

### DIFF
--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/AssetGroupException.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/AssetGroupException.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -33,7 +34,7 @@ public class AssetGroupException {
 
 	@Id
 	@Column(name = "id_", unique = true, nullable = false)
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private long id;
 	private String groupName;
 	private String targetType;

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/Task.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/Task.java
@@ -18,6 +18,7 @@ package com.tmobile.pacman.api.admin.repository.model;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -29,7 +30,7 @@ import javax.persistence.UniqueConstraint;
 @Table(name = "task", uniqueConstraints = @UniqueConstraint(columnNames = "id"))
 public class Task {
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id", unique = true, nullable = false)
 	private Long id;
 	private String index;

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/User.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/User.java
@@ -20,6 +20,7 @@ import java.util.Date;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -32,7 +33,7 @@ import javax.persistence.UniqueConstraint;
 public class User {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id", unique = true, nullable = false)
 	private Long id;
 

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/UserPreferences.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/repository/model/UserPreferences.java
@@ -18,6 +18,7 @@ package com.tmobile.pacman.api.admin.repository.model;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
@@ -30,7 +31,7 @@ import javax.persistence.UniqueConstraint;
 public class UserPreferences {
 
 	@Id
-	@GeneratedValue
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id", unique = true, nullable = false)
 	private Long id;
 

--- a/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/service/CommonService.java
+++ b/api/pacman-api-admin/src/main/java/com/tmobile/pacman/api/admin/service/CommonService.java
@@ -95,6 +95,9 @@ public class CommonService {
 		if (payLoad != null) {
             entity = new NStringEntity(payLoad, ContentType.APPLICATION_JSON);
         }
+		if(!endpoint.startsWith("/")) {
+        	endpoint = "/"+endpoint;
+        }
         try {
             return getRestClient().performRequest(method, endpoint, Collections.<String, String>emptyMap(), entity);
         } catch (IOException exception) {

--- a/installer/terraform/oss-api/DB.sql
+++ b/installer/terraform/oss-api/DB.sql
@@ -84,7 +84,7 @@ CREATE TABLE `cf_AssetGroupDetails` (
 DROP TABLE IF EXISTS `cf_AssetGroupException`;
 
 CREATE TABLE `cf_AssetGroupException` (
-  `id_` bigint(20) NOT NULL,
+  `id_` bigint(20) NOT NULL AUTO_INCREMENT,
   `groupName` varchar(75) COLLATE utf8_bin DEFAULT NULL,
   `targetType` varchar(75) COLLATE utf8_bin DEFAULT NULL,
   `ruleName` varchar(200) COLLATE utf8_bin DEFAULT NULL,
@@ -94,7 +94,7 @@ CREATE TABLE `cf_AssetGroupException` (
   `exceptionReason` varchar(2000) COLLATE utf8_bin DEFAULT NULL,
   `dataSource` varchar(75) COLLATE utf8_bin DEFAULT NULL,
   PRIMARY KEY (`id_`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+) ENGINE=InnoDB AUTO_INCREMENT=2000 DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 
 /*Table structure for table `cf_AssetGroupOwnerDetails` */
 

--- a/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/CommonUtils.java
+++ b/jobs/pacman-rule-engine-2.0/src/main/java/com/tmobile/pacman/util/CommonUtils.java
@@ -30,6 +30,7 @@ import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -69,9 +70,6 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import sun.misc.BASE64Decoder;
-import sun.misc.BASE64Encoder;
-
 import com.amazonaws.util.StringUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -93,7 +91,6 @@ import com.tmobile.pacman.commons.rule.Annotation;
 /**
  * The Class CommonUtils.
  */
-@SuppressWarnings("restriction")
 public class CommonUtils {
 
     /** The Constant TLS. */
@@ -843,10 +840,9 @@ public class CommonUtils {
      * @return the string
      */
     public static String encryptB64(String plainText) {
-        BASE64Encoder encoder = new BASE64Encoder();
         byte[] salt = new byte[8];
         random.nextBytes(salt);
-        return encoder.encode(salt) + encoder.encode(plainText.getBytes());
+        return Base64.getEncoder().encodeToString(salt) + Base64.getEncoder().encodeToString(plainText.getBytes());
     }
 
     /**
@@ -863,8 +859,7 @@ public class CommonUtils {
         // bytes (i.e., a total of 24 bits) can therefore be represented by four
         // 6-bit base64 digits.
         String cipher = text.substring(12);
-        BASE64Decoder decoder = new BASE64Decoder();
-        return new String(decoder.decodeBuffer(cipher));
+        return new String(Base64.getDecoder().decode(cipher));
     }
 
     /**
@@ -909,7 +904,7 @@ public class CommonUtils {
      * @throws UnsupportedEncodingException the unsupported encoding exception
      */
     private static SecretKeySpec getSecretKey(final String baseKey) throws UnsupportedEncodingException {
-        String secretKeyValue = new BASE64Encoder().encode(baseKey.substring(0, 16).getBytes()).substring(0, 16);
+        String secretKeyValue = Base64.getEncoder().encodeToString(baseKey.substring(0, 16).getBytes()).substring(0, 16);
         return new SecretKeySpec(secretKeyValue.getBytes(StandardCharsets.UTF_8), "AES");
     }
 


### PR DESCRIPTION
Adding backward slash to endpoint for Asset Group Edit service
Using Java8 Base64 encoding instead of Sun classes
Adding @GeneratedValue(strategy = GenerationType.IDENTITY) instead of @GeneratedValue