### PR TITLE
fix mysql command argument

### DIFF
--- a/installer/resources/pacbot_app/import_db.py
+++ b/installer/resources/pacbot_app/import_db.py
@@ -120,7 +120,7 @@ class ImportDbSql(NullResource):
         local_execs = [
             {
                 'local-exec': {
-                    'command': "mysql -u %s -p%s -h %s < %s" % (db_user_name, db_password, db_host, ReplaceSQLPlaceHolder.dest_file)
+                    'command': "mysql -u %s -p %s -h %s < %s" % (db_user_name, db_password, db_host, ReplaceSQLPlaceHolder.dest_file)
                 }
             }
 


### PR DESCRIPTION
Added a space character between -p argument and the password variable %s. Lack of space between these two caused an error when trying to run the formatted command.

Aha! Link: https://t-mobile1t-mobile.aha.io/features/PM-435