### PR TITLE
Updated jcenter URL to use https

### DIFF
--- a/commons/pac-batch-commons/pom.xml
+++ b/commons/pac-batch-commons/pom.xml
@@ -283,7 +283,7 @@
 			</snapshots>
 			<id>central</id>
 			<name>bintray-plugins</name>
-			<url>http://jcenter.bintray.com</url>
+			<url>https://jcenter.bintray.com</url>
 		</pluginRepository>
 	</pluginRepositories>
 


### PR DESCRIPTION
Starting in January 2020, jcenter only supports https access hence we were receiving 403 during maven builds.

Switch to https URL fixed this issue.

More info here: https://jfrog.com/blog/secure-jcenter-with-https/