### PR TITLE
add update to the es query for stats repo

### DIFF
--- a/api/pacman-api-statistics/src/main/java/com/tmobile/pacman/api/statistics/repository/StatisticsRepositoryImpl.java
+++ b/api/pacman-api-statistics/src/main/java/com/tmobile/pacman/api/statistics/repository/StatisticsRepositoryImpl.java
@@ -156,7 +156,7 @@ public class StatisticsRepositoryImpl implements StatisticsRepository, Constants
             StringBuilder urlToQueryBuffer = new StringBuilder(esUrl).append("/").append(AWS).append("/")
                     .append(SEARCH);
             StringBuilder requestBody = new StringBuilder(
-                    "{\"query\":{\"bool\":{}},\"aggs\":{\"accounts\":{\"terms\":{\"field\":\"accountname.keyword\",\"size\":10000}}}}");
+                    "{\"query\":{\"bool\":{}},\"aggs\":{\"accounts\":{\"terms\":{\"field\":\"accountid.keyword\",\"size\":10000}}}}");
             String responseDetails = PacHttpUtils.doHttpPost(urlToQueryBuffer.toString(), requestBody.toString());
             JsonObject paramObj = parser.parse(responseDetails).getAsJsonObject();
             JsonObject aggsJson = (JsonObject) parser.parse(paramObj.get(AGGS).toString());


### PR DESCRIPTION
Fix for #460
See comments on the Fix section, should be accountid as local es query on kibana confirms
Problem is the query needs to use accountid.
Here's what it returns if it uses the accountid in the stats query
"buckets": [
        {
          "key": "xxx2",
          "doc_count": 61542
        },
        {
          "key": "xxx3",
          "doc_count": 11758
        },
        {
          "key": "xxx4",
          "doc_count": 1860
        }
      ]
    }
  }