### PR TITLE
https://bootstrap.pypa.io/get-pip.py python 3 error

### DIFF
--- a/installer/resources/pacbot_app/files/api_docker/dockerfile
+++ b/installer/resources/pacbot_app/files/api_docker/dockerfile
@@ -1,6 +1,8 @@
 FROM openjdk:8
 ENV RUN_ARGS="--server.port=80 --server.ssl.enabled=false"
-RUN cd /tmp/ && curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py && pip install awscli && cd -
+RUN apt update -y
+RUN apt install python3-pip -y
+RUN pip3 install awscli
 COPY entrypoint.sh ./entrypoint.sh
 RUN chmod +x ./entrypoint.sh
 #ENTRYPOINT ["./entrypoint.sh"]

--- a/installer/resources/pacbot_app/files/ui_docker/dockerfile
+++ b/installer/resources/pacbot_app/files/ui_docker/dockerfile
@@ -7,7 +7,7 @@ ENV NGINX_VERSION 1.14.0
 ARG HTML_FILE
 ENV HTML_FILE=$HTML_FILE
 
-RUN apk add --no-cache curl python unzip && cd /tmp/ && curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py && pip install awscli
+RUN apk add --no-cache curl py3-pip unzip && pip3 install awscli
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
     && CONFIG="\


### PR DESCRIPTION
When initially deploying Pacbot, I received a message that https://bootstrap.pypa.io/get-pip.py was not compatible with python2.7 and to run a different url. It comes from this code block:

```python
if this_python < min_version:
    message_parts = [
        "This script does not work on Python {}.{}".format(*this_python),
        "The minimum supported Python version is {}.{}.".format(*min_version),
        "Please use https://bootstrap.pypa.io/pip/{}.{}/get-pip.py instead.".format(*this_python),
    ]
    print("ERROR: " + " ".join(message_parts))
    sys.exit(1)
```

This is because the images you use currently do not come with python3x installed. As a result, the dockerfiles would not build. I decided to modify them to install pip3 and install awscli that way. Another option would be to continue using get-pip but change the url to the 2.7 version. I'm not sure which direction you'd prefer to go, but I thought I would put it out here in any case.